### PR TITLE
Update getBroadcast requestCode to match tag

### DIFF
--- a/localnotification/android/src/GodotLocalNotification.java
+++ b/localnotification/android/src/GodotLocalNotification.java
@@ -73,7 +73,7 @@ public class GodotLocalNotification extends Godot.SingletonBase {
         i.putExtra("notification_id", tag);
         i.putExtra("message", message);
         i.putExtra("title", title);
-        PendingIntent sender = PendingIntent.getBroadcast(activity, 0, i, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent sender = PendingIntent.getBroadcast(activity, tag, i, PendingIntent.FLAG_UPDATE_CURRENT);
         return sender;
     }
 


### PR DESCRIPTION
The `getBroadcast` method was previously using a single hardcoded
`requestCode` for every call. As a consequence, it wasn't possible to
set several notifications. Each new call to `showLocalNotification`
was updating the previous notification.

This change allows to setup several notifications by using distinct
tags. One can still update a previously set notification by specifying
the same tag as the one used during the previous call to
`showLocalNotification`.