### PR TITLE
ios: daily notification implement

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Add wrapper `scripts/localnotification.gd` into autoloading list in your project
 Show notification with `title` and `message` after delay of `interval` seconds with `tag`. You can override notification by it's tag before it was fired.
 If you defined `repeating_interval` the notification will be fired in a loop until you cancelled it.
 
+### show_daily(message: String, title: String, hour: int, minute: int, tag: int = 1)
+
+Show notification daily at specific hour and minute (in 24 hour format).
+You can overide the notification with new time, or cancel it with tag and register a new one.
+
+*Need help*: Currently just support ios, need help on Android
+
 ### cancel(tag: int)
 
 Cancel previously created notification.

--- a/ios-framework/gdnative_ios/src/LocalNotification.hpp
+++ b/ios-framework/gdnative_ios/src/LocalNotification.hpp
@@ -27,6 +27,7 @@ public:
 
     void showLocalNotification(const godot::String message, const godot::String title, int interval, int tag);
     void showRepeatingNotification(const godot::String message, const godot::String title, int interval, int tag, int repeating_interval);
+    void showDailyNotification(const godot::String message, const godot::String title, int hour, int minute, int tag);
     void cancelLocalNotification(int tag);
     void cancelAllNotifications();
     bool isEnabled();

--- a/scripts/localnotification.gd
+++ b/scripts/localnotification.gd
@@ -32,6 +32,9 @@ func show(message: String, title: String, interval: int, tag: int = 1, repeat_du
         else:
             _ln.showRepeatingNotification(message, title, interval, tag, repeat_duration)
 
+func show_daily(message: String, title: String, hour: int, minute: int, tag: int = 1) -> void:
+    _ln.showRepeatingNotification(message, title, hour, minute, tag)
+
 func cancel(tag: int = 1) -> void:
     if _ln != null:
         _ln.cancelLocalNotification(tag)


### PR DESCRIPTION
This will implement a brand new function call show_daily. Help to show notification daily.

Currently i just implement for ios, as for Android, i'll try to implement it later cause it working fine now with `interval` and `repeating_interval`.

Testing binary:
[local-notification_0.2.2_ios.tgz.zip](https://github.com/DrMoriarty/godot-local-notification/files/7151345/local-notification_0.2.2_ios.tgz.zip)
