### PR TITLE
Fixs pending Intent issue on Godot 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,23 +16,27 @@ Add wrapper `scripts/localnotification.gd` into autoloading list in your project
 
 ## API
 
-### show(message: String, title: String, interval: float, tag: int, repeating_interval: int = 0)
+### showLocalNotification(message: String, title: String, interval: float, tag: int)
 
 Show notification with `title` and `message` after delay of `interval` seconds with `tag`. You can override notification by it's tag before it was fired.
-If you defined `repeating_interval` the notification will be fired in a loop until you cancelled it.
+
+### showRepeatingNotification(message: String, title: String, interval: float, tag: int, repeat_duration: int)
+Show notification with `title` and `message` after delay of `interval` seconds with `tag`. You can override notification by it's tag before it was fired.
+`repeating_interval` the notification will be fired in a loop until you cancelled it.
+
 
 ### show_daily(message: String, title: String, hour: int, minute: int, tag: int = 1)
-
+(IOS Only)
 Show notification daily at specific hour and minute (in 24 hour format).
 You can overide the notification with new time, or cancel it with tag and register a new one.
 
 *Need help*: Currently just support ios, need help on Android
 
-### cancel(tag: int)
+### cancelLocalNotification(tag: int)
 
 Cancel previously created notification.
 
-### cancel_all()
+### cancelAllNotifications()
 
 Cancel all pending notifications (implemented for iOS only).
 
@@ -50,7 +54,7 @@ Check if notification permission was granted by user (iOS only).
 
 ### register_remote_notification()
 
-Request system token for push notifications.
+Request system token for push notifications. (iOS only)
 
 ### get_device_token() -> String
 

--- a/android-plugin/build.gradle
+++ b/android-plugin/build.gradle
@@ -49,6 +49,7 @@ dependencies {
      */
     compileOnly fileTree(dir: 'libs', include: ['godot-lib*.aar'])
     implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.work:work-runtime:2.7.1'
 }
 
 group = 'ru.mobilap.godot'

--- a/android-plugin/build.gradle
+++ b/android-plugin/build.gradle
@@ -20,13 +20,13 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 32
-    buildToolsVersion "29.0.3"
+    buildToolsVersion "32.0.0"
 
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 32
         versionCode 1
-        versionName "1.0"
+        versionName "1.1"
     }
 
     // Used to customize the name of generated AAR file.
@@ -47,7 +47,7 @@ dependencies {
      necessary since the Godot editor will also provide a version of the godot
      library when building the final binary.
      */
-    compileOnly fileTree(dir: 'libs', include: ['godot-lib*.aar'])
+    implementation 'io.github.m4gr3d:godot:3.5.1.stable'
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.work:work-runtime:2.7.1'
 }

--- a/android-plugin/build.gradle
+++ b/android-plugin/build.gradle
@@ -19,12 +19,12 @@ allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.1"
+    compileSdkVersion 32
+    buildToolsVersion "29.0.3"
 
     defaultConfig {
-        minSdkVersion 18
-        targetSdkVersion 29
+        minSdkVersion 19
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
     }

--- a/android-plugin/build.gradle
+++ b/android-plugin/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.0'
+        classpath 'com.android.tools.build:gradle:3.6.4'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.+'
     }
 }
@@ -12,19 +12,19 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
     buildToolsVersion "32.0.0"
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 32
+        targetSdkVersion 33
         versionCode 1
         versionName "1.1"
     }

--- a/android-plugin/src/main/AndroidManifest.xml
+++ b/android-plugin/src/main/AndroidManifest.xml
@@ -17,4 +17,5 @@
     <receiver android:name="ru.mobilap.localnotification.LocalNotificationReceiver" android:process=":remote" />
   </application>
   <uses-permission android:name="com.android.alarm.permission.SET_ALARM"/>
+  <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
 </manifest>

--- a/android-plugin/src/main/java/ru/mobilap/localnotification/LocalNotification.java
+++ b/android-plugin/src/main/java/ru/mobilap/localnotification/LocalNotification.java
@@ -146,7 +146,7 @@ public class LocalNotification extends GodotPlugin {
         i.putExtra("notification_id", tag);
         i.putExtra("message", message);
         i.putExtra("title", title);
-        PendingIntent sender = PendingIntent.getBroadcast(getActivity(), tag, i, PendingIntent.FLAG_IMMUTABLE);
+        PendingIntent sender = PendingIntent.getBroadcast(getActivity(), tag, i, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
         return sender;
     }
 

--- a/android-plugin/src/main/java/ru/mobilap/localnotification/LocalNotification.java
+++ b/android-plugin/src/main/java/ru/mobilap/localnotification/LocalNotification.java
@@ -144,7 +144,7 @@ public class LocalNotification extends GodotPlugin {
         i.putExtra("notification_id", tag);
         i.putExtra("message", message);
         i.putExtra("title", title);
-        PendingIntent sender = PendingIntent.getBroadcast(getActivity(), tag, i, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent sender = PendingIntent.getBroadcast(getActivity(), tag, i, PendingIntent.FLAG_IMMUTABLE);
         return sender;
     }
 

--- a/android-plugin/src/main/java/ru/mobilap/localnotification/LocalNotification.java
+++ b/android-plugin/src/main/java/ru/mobilap/localnotification/LocalNotification.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Calendar;
+
+import org.godotengine.godot.plugin.UsedByGodot;
 import org.json.JSONObject;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -74,18 +76,18 @@ public class LocalNotification extends GodotPlugin {
     }
 
     // Public methods
-
+    @UsedByGodot
     public void init() {
     }
-
+    @UsedByGodot
     public boolean isInited() {
         return true;
     }
-
+    @UsedByGodot
     public boolean isEnabled() {
         return true;
     }
-
+    @UsedByGodot
     public void showLocalNotification(String message, String title, int interval, int tag) {
         if(interval <= 0) return;
         Log.d(TAG, "showLocalNotification: "+message+", "+Integer.toString(interval)+", "+Integer.toString(tag));
@@ -102,7 +104,7 @@ public class LocalNotification extends GodotPlugin {
             am.set(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis(), sender);
         }
     }
-    
+    @UsedByGodot
     public void showRepeatingNotification(String message, String title, int interval, int tag, int repeat_duration) {
         if(interval <= 0) return;
         Log.d(TAG, "showRepeatingNotification: "+message+", "+Integer.toString(interval)+", "+Integer.toString(tag)+" Repeat after: "+Integer.toString(repeat_duration));
@@ -119,20 +121,20 @@ public class LocalNotification extends GodotPlugin {
             am.setInexactRepeating(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis(), repeat_duration*1000, sender);
         }
     }
-
+    @UsedByGodot
     public void cancelLocalNotification(int tag) {
         AlarmManager am = (AlarmManager)getActivity().getSystemService(getActivity().ALARM_SERVICE);
         PendingIntent sender = getPendingIntent("", "", tag);
         am.cancel(sender);
     }
-
+    @UsedByGodot
     public void cancelAllNotifications() {
         Log.w(TAG, "cancelAllNotifications not implemented");
     }
-
+    @UsedByGodot
     public void register_remote_notification() {
     }
-
+    @UsedByGodot
     public String get_device_token() {
         return "";
     }
@@ -193,17 +195,17 @@ public class LocalNotification extends GodotPlugin {
         }
         intentWasChecked = true;
     }
-
+    @UsedByGodot
     public Dictionary get_notification_data() {
         if(!intentWasChecked) checkIntent();
         return notificationData;
     }
-
+    @UsedByGodot
     public String get_deeplink_action() {
         if(!intentWasChecked) checkIntent();
         return action;
     }
-
+    @UsedByGodot
     public String get_deeplink_uri() {
         if(!intentWasChecked) checkIntent();
         return uri;

--- a/android-plugin/src/main/java/ru/mobilap/localnotification/LocalNotificationReceiver.java
+++ b/android-plugin/src/main/java/ru/mobilap/localnotification/LocalNotificationReceiver.java
@@ -47,7 +47,7 @@ public class LocalNotificationReceiver extends BroadcastReceiver {
         
         Intent intent2 = new Intent(context, appClass);
         intent2.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent2, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent2, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
         int iconID = context.getResources().getIdentifier("icon", "mipmap", context.getPackageName());
         int notificationIconID = context.getResources().getIdentifier("notification_icon", "mipmap", context.getPackageName());


### PR DESCRIPTION
Fixes this specific bug
Exception java.lang.IllegalArgumentException: org.godotengine.sweepit: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
  at android.app.PendingIntent.checkFlags (PendingIntent.java:375)
  at android.app.PendingIntent.getBroadcastAsUser (PendingIntent.java:645)
  at android.app.PendingIntent.getBroadcast (PendingIntent.java:632)
  at ru.mobilap.localnotification.LocalNotification.getPendingIntent (LocalNotification.java:147)
  at ru.mobilap.localnotification.LocalNotification.cancelLocalNotification (LocalNotification.java:125)
  at org.godotengine.godot.GodotLib.step
  at org.godotengine.godot.GodotRenderer.onDrawFrame (GodotRenderer.java:57)
  at org.godotengine.godot.gl.GLSurfaceView$GLThread.guardedRun (GLSurfaceView.java:1576)
  at org.godotengine.godot.gl.GLSurfaceView$[GLThread.run](https://www.youtube.com/redirect?event=comments&redir_token=QUFFLUhqa09KV0JMYW4wVWlqZHRwaTZIWmlmb19DTUh3QXxBQ3Jtc0trMmRkUTZiYW5SVFY3UVE0Qml3Qy1wRnVBUGNlSG1Bek5ZaG9TTnlZc0xFR3dCcklkRzhtTHVLRURkYTNfY3NYS0lON2ZtWlc3OWphSlNZemNLYWlzdDFpbnU5bTRzSHc1R3YtYTJObjJDcl9ndzZsZw&q=http%3A%2F%2Fglthread.run%2F&stzid=Ugwec7PYlYwOy1DrcTR4AaABAg.9gAAFwTXlin9gBnihWVOcj) (GLSurfaceView.java:1278)

let me know if theres anything I need to change.